### PR TITLE
Fixes #1: Pass quic_override option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ resource "google_compute_target_https_proxy" "default" {
   name             = "${var.name}-https-proxy"
   url_map          = "${element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)}"
   ssl_certificates = ["${compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link))}"]
+  quic_override    = "NONE"
 }
 
 resource "google_compute_ssl_certificate" "default" {


### PR DESCRIPTION
### Changes

* Pass the `quic_override` to NONE by default. We can make this configurable if needed.
```tf
module "lb-app" {
  source            = "github.com/qumu/terraform-google-lb-http.git?ref=1.0.11"
```

### Testing

* Ensure the run completes
```tf
module.service_qumucloud.module.lb-app.google_compute_target_https_proxy.default: Modifying... (ID: agd-app-as1-p-https-proxy)
  quic_override: "ENABLE" => "NONE"
```