### PR TITLE
Fixes #2: Manage more options for google_compute_backend_service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,16 +78,20 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
-  project         = "${var.project}"
-  count           = "${length(var.backend_params)}"
-  name            = "${var.name}-backend-${count.index}"
-  port_name       = "${element(split(",", element(var.backend_params, count.index)), 1)}"
-  protocol        = "${var.backend_protocol}"
-  timeout_sec     = "${element(split(",", element(var.backend_params, count.index)), 3)}"
-  backend         = ["${var.backends["${count.index}"]}"]
-  health_checks   = ["${element(google_compute_http_health_check.default.*.self_link, count.index)}"]
-  security_policy = "${var.security_policy}"
-  enable_cdn      = "${var.cdn}"
+  provider                        = "google-beta"
+  project                         = "${var.project}"
+  count                           = "${length(var.backend_params)}"
+  name                            = "${var.name}-backend-${count.index}"
+  port_name                       = "${element(split(",", element(var.backend_params, count.index)), 1)}"
+  protocol                        = "${var.backend_protocol}"
+  timeout_sec                     = "${element(split(",", element(var.backend_params, count.index)), 3)}"
+  backend                         = ["${var.backends["${count.index}"]}"]
+  health_checks                   = ["${element(google_compute_http_health_check.default.*.self_link, count.index)}"]
+  security_policy                 = "${var.security_policy}"
+  enable_cdn                      = "${var.cdn}"
+  connection_draining_timeout_sec = "${var.connection_draining_timeout_sec}"
+  session_affinity                = "${var.session_affinity}"
+  affinity_cookie_ttl_sec         = "${var.affinity_cookie_ttl_sec}"
 }
 
 resource "google_compute_http_health_check" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -115,3 +115,21 @@ variable cdn {
   description = "Set to `true` to enable cdn on backend."
   default     = "false"
 }
+
+variable "connection_draining_timeout_sec" {
+  type = "string"
+  description = "Time for which instance will be drained (not accept new connections, but still work to finish started)."
+  default = "300"
+}
+
+variable "session_affinity" {
+  type = "string"
+  description = "Type of session affinity to use"
+  default = "NONE"
+}
+
+variable "affinity_cookie_ttl_sec" {
+  type = "string"
+  description = "Lifetime of cookies in seconds if session_affinity is GENERATED_COOKIE."
+  default = "900"
+}


### PR DESCRIPTION
### Changes

* Add more LB parameters
* Requires 2.0 version of google-beta provider

### Testing

```tf
module.service_qumucloud.module.lb-app.google_compute_backend_service.default: Modifying... (ID: agd-app-as1-p-backend-0)
  affinity_cookie_ttl_sec:                         "3600" => "900"
  backend.1041982080.balancing_mode:               "UTILIZATION" => ""
  backend.1041982080.capacity_scaler:              "1" => "0"
  backend.1041982080.description:                  "" => ""
  backend.1041982080.group:                        "https://www.googleapis.com/compute/beta/projects/qumu-abhishek/regions/asia-south1/instanceGroups/agd-app-as1-p" => ""
  backend.1041982080.max_connections:              "0" => "0"
  backend.1041982080.max_connections_per_instance: "0" => "0"
  backend.1041982080.max_rate:                     "0" => "0"
  backend.1041982080.max_rate_per_instance:        "0" => "0"
  backend.1041982080.max_utilization:              "0.8" => "0"
  backend.4139062735.balancing_mode:               "" => "RATE"
  backend.4139062735.capacity_scaler:              "" => "1"
  backend.4139062735.description:                  "" => ""
  backend.4139062735.group:                        "" => "https://www.googleapis.com/compute/v1/projects/qumu-abhishek/regions/asia-south1/instanceGroups/agd-app-as1-p"
  backend.4139062735.max_connections:              "" => ""
  backend.4139062735.max_connections_per_instance: "" => ""
  backend.4139062735.max_rate:                     "" => ""
  backend.4139062735.max_rate_per_instance:        "" => "100"
  backend.4139062735.max_utilization:              "" => "0.8"
module.service_qumucloud.module.lb-app.google_compute_backend_service.default: Modifications complete after 4s (ID: agd-app-as1-p-backend-0)

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```