### PR TITLE
Fixes #5: Manage backend options per backend

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,9 +89,9 @@ resource "google_compute_backend_service" "default" {
   health_checks                   = ["${element(google_compute_http_health_check.default.*.self_link, count.index)}"]
   security_policy                 = "${var.security_policy}"
   enable_cdn                      = "${var.cdn}"
-  connection_draining_timeout_sec = "${var.connection_draining_timeout_sec}"
-  session_affinity                = "${var.session_affinity}"
-  affinity_cookie_ttl_sec         = "${var.affinity_cookie_ttl_sec}"
+  connection_draining_timeout_sec = "${lookup(var.backend_service_params[count.index], "connection_draining_timeout_sec", var.connection_draining_timeout_sec)}"
+  session_affinity                = "${lookup(var.backend_service_params[count.index], "session_affinity", var.session_affinity)}"
+  affinity_cookie_ttl_sec         = "${lookup(var.backend_service_params[count.index], "affinity_cookie_ttl_sec", var.affinity_cookie_ttl_sec)}"
 }
 
 resource "google_compute_http_health_check" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -116,6 +116,11 @@ variable cdn {
   default     = "false"
 }
 
+variable "backend_service_params" {
+  type = "map"
+  description = "Backend Service Parameters"
+}
+
 variable "connection_draining_timeout_sec" {
   type = "string"
   description = "Time for which instance will be drained (not accept new connections, but still work to finish started)."


### PR DESCRIPTION
### Changes

* Add support for custom backend service parameters.

### Configuration

```tf
module "lb-app" {
  source            = "github.com/qumu/terraform-google-lb-http.git?ref=issue%2F5"
  name              = "${local.lb_name}"
  [...]
  backend_service_params = {
    "0" = {
      affinity_cookie_ttl_sec = 900,
      connection_draining_timeout_sec = 300,
      session_affinity = "GENERATED_COOKIE"
    },
    "1" = {
      session_affinity = "NONE"
    }
  }
```

### Testing

* Ensure we have multiple backends with custom map rules