### PR TITLE
Fixes #7: Increase LB HC timeout values

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,11 +95,15 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_http_health_check" "default" {
-  project      = "${var.project}"
-  count        = "${length(var.backend_params)}"
-  name         = "${var.name}-backend-${count.index}"
-  request_path = "${element(split(",", element(var.backend_params, count.index)), 0)}"
-  port         = "${element(split(",", element(var.backend_params, count.index)), 2)}"
+  project             = "${var.project}"
+  count               = "${length(var.backend_params)}"
+  name                = "${var.name}-backend-${count.index}"
+  request_path        = "${element(split(",", element(var.backend_params, count.index)), 0)}"
+  port                = "${element(split(",", element(var.backend_params, count.index)), 2)}"
+  check_interval_sec  = 30
+  healthy_threshold   = 1
+  unhealthy_threshold = 2
+  timeout_sec         = 10
 }
 
 # Create firewall rule for each backend in each network specified, uses mod behavior of element().


### PR DESCRIPTION
### Changes

* Update default values based on HAP

### Testing

* Ensure values are updated on the LB
```bash
------------------------------------------------------------------------
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

~ module.service_qumucloud.module.lb-app.google_compute_http_health_check.default[0]
      check_interval_sec: "5" => "30"
      healthy_threshold:  "2" => "1"
      timeout_sec:        "5" => "10"

  ~ module.service_qumucloud.module.lb-app.google_compute_http_health_check.default[1]
      check_interval_sec: "5" => "30"
      healthy_threshold:  "2" => "1"
      timeout_sec:        "5" => "10"

```